### PR TITLE
Create AbstractHolder.java

### DIFF
--- a/src/main/java/net/plasmere/streamline/utils/holders/AbstractHolder.java
+++ b/src/main/java/net/plasmere/streamline/utils/holders/AbstractHolder.java
@@ -1,0 +1,16 @@
+package net.plasmere.streamline.utils.holders;
+
+import net.md_5.bungee.api.ProxyServer;
+
+public abstract class AbstractHolder<T> {
+    String plugin;
+    Class<?> api;
+
+    AbstractHolder(String plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean isPresent() {return (ProxyServer.getInstance().getPluginManager().getPlugin(this.plugin) != null);}
+    public void setAPI(Class<?> api) {this.api = api;}
+    public Class<?> getAPI() {return this.api;}
+}


### PR DESCRIPTION
Creates an AbstractHolder class which allows for easier expandability when adding a new holder to hold an API for a new dependency plugin

It holds the API and minimizes classes and saves code.
In the next pull request I changed LPHolder to take use of this advantage and will be able to be used
as an example of how this works.
LPHolder, and instead of doing .enabled do `.isPresent()` and to get the API class you can do `.getAPI()`
If you wish to change the API class from outside of the holder do so doing `.setAPI()`